### PR TITLE
fix(norelease): add run sub command to docker entry, update readme, revert hyphen change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=builder /workspace/main .
 COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
 USER 65532:65532
 
-ENTRYPOINT ["/main"]
+ENTRYPOINT ["/main", "run"]

--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ Viper's global config is configured in `cmd/root.go#initConfig()`. We're using i
 
 Binding flags should be done in each command's `init()` function. Calling `viper.BindPFlags(flags)` binds whatever configuration viper has found to viper. That could be a .yaml file, or env vars, or cli flags like --my_flag, this call makes viper aware of the flags and configs.
 
-### How does the config struct and viper work together?
-Once your flags are defined and bound to viper, you can call `viper.AllSettings()` which will give you a map[string]interface{} of all of your flags. We're using a catalyst utility function to marshall this map into json, and then marshall that json to a config struct. Make sure your struct's `json` tags match your flag names.
-
-Binding of viper to config struct works with any source of config that viper supports. This is because we're getting all of the settings and marshalling all of them at once, so it doesn't matter if config is from .yaml files, env vars, or cli arguments.
-
 ### Why should I use `_` instead of `-` in my flag names?
 Simplicity. If your flag names are all strings separated with `_` then you can simply use an identically named environment variable to set the setting. If you use `-` then there's other viper config and trickery you have to do to get it to read the env vars correctly. I don't believe it's worth the extra stuff, just use `_` and it works well out of the box.
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,7 +32,7 @@ var runCmd = &cobra.Command{
 }
 
 type runCmdConfig struct {
-	ExampleServerPort int
+	Port              int
 	EnableHealthCheck bool
 	HealthCheckPath   string
 	HealthCheckPort   int
@@ -40,7 +40,7 @@ type runCmdConfig struct {
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-	runCmd.PersistentFlags().Int("example-server-port", 8080, "port for example http server")
+	runCmd.PersistentFlags().Int("port", 8080, "port for example http server")
 	runCmd.PersistentFlags().Bool("enable-health-check", true, "when true, runs an http server on port 6000 that can be used for a health check for things like kubernetes with GET /health")
 	runCmd.PersistentFlags().String("health-check-path", "/health", "path to serve health check on when health check is enabled")
 	runCmd.PersistentFlags().Int("health-check-port", 6000, "port to serve health check on when health check is enabled")
@@ -64,7 +64,7 @@ func initRunCmdConfig() *runCmdConfig {
 	// instantiate config struct
 	config := &runCmdConfig{}
 
-	config.ExampleServerPort = viper.GetInt("example-server-port")
+	config.Port = viper.GetInt("port")
 	config.EnableHealthCheck = viper.GetBool("enable-health-check")
 	config.HealthCheckPath = viper.GetString("health-check-path")
 	config.HealthCheckPort = viper.GetInt("health-check-port")
@@ -94,7 +94,7 @@ func runExampleServer(config *runCmdConfig) {
 		fmt.Fprintf(w, "Hello!")
 	})
 
-	address := fmt.Sprintf(":%d", config.ExampleServerPort)
+	address := fmt.Sprintf(":%d", config.Port)
 	logging.Log.WithFields(logrus.Fields{"address": address, "path": "/"}).Info("starting example server")
 	err := http.ListenAndServe(address, nil)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"net/http"
 
@@ -41,16 +40,9 @@ type runCmdConfig struct {
 func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.PersistentFlags().Int("port", 8080, "port for example http server")
-	runCmd.PersistentFlags().Bool("enable-health-check", true, "when true, runs an http server on port 6000 that can be used for a health check for things like kubernetes with GET /health")
-	runCmd.PersistentFlags().String("health-check-path", "/health", "path to serve health check on when health check is enabled")
-	runCmd.PersistentFlags().Int("health-check-port", 6000, "port to serve health check on when health check is enabled")
-
-	// set environment variable prefix to prevent any overlapping
-	viper.SetEnvPrefix("APP")
-
-	// replace "-" with "_" for environment variables
-	replacer := strings.NewReplacer("-", "_")
-	viper.SetEnvKeyReplacer(replacer)
+	runCmd.PersistentFlags().Bool("enable_health_check", true, "when true, runs an http server on port 6000 that can be used for a health check for things like kubernetes with GET /health")
+	runCmd.PersistentFlags().String("health_check_path", "/health", "path to serve health check on when health check is enabled")
+	runCmd.PersistentFlags().Int("health_check_port", 6000, "port to serve health check on when health check is enabled")
 
 	// bind flags
 	err := viper.BindPFlags(runCmd.PersistentFlags())
@@ -65,9 +57,9 @@ func initRunCmdConfig() *runCmdConfig {
 	config := &runCmdConfig{}
 
 	config.Port = viper.GetInt("port")
-	config.EnableHealthCheck = viper.GetBool("enable-health-check")
-	config.HealthCheckPath = viper.GetString("health-check-path")
-	config.HealthCheckPort = viper.GetInt("health-check-port")
+	config.EnableHealthCheck = viper.GetBool("enable_health_check")
+	config.HealthCheckPath = viper.GetString("health_check_path")
+	config.HealthCheckPort = viper.GetInt("health_check_port")
 
 	logging.Log.WithField("settings", fmt.Sprintf("%+v", *config)).Debug("viper settings")
 


### PR DESCRIPTION
- add the run subcommand to the docker entrypoint so that the container actually starts when you run it in kubernetes
- shorten the example port name, so that it is easier to use out of the box
- remove the part of the documentation about the automatic config struct, because viper doesn't return consistent types causing env vars and cli flags to not work together
- revert the cli flag hyphen change, because the readme has an explanation on using underscores over hyphens, which was compelling, so I reverted that change to match what is advocated for in the readme.